### PR TITLE
Adding recursion for SDP Codec ordering to find all H264 profiles

### DIFF
--- a/src/sdputils.js
+++ b/src/sdputils.js
@@ -257,11 +257,18 @@
      }
    
      // If the codec is available, set it as the default in m line.
-     var payload = getCodecPayloadType(sdpLines, codec);
-     if (payload) {
-       sdpLines[mLineIndex] = setDefaultCodec(sdpLines[mLineIndex], payload);
+     var payload = null;
+     for (var i = 0; i < sdpLines.length; i++) {
+      var index = findLineInRange(sdpLines, i, -1, 'a=rtpmap', codec);
+      if(index !== null) {
+        payload = getCodecPayloadTypeFromLine(sdpLines[index])
+        if (payload) {
+          sdpLines[mLineIndex] = setDefaultCodec(sdpLines[mLineIndex], payload);
+          i = index++;
+        }
+      }
      }
-   
+     
      sdp = sdpLines.join('\r\n');
      return sdp;
    }

--- a/src/sdputils.js
+++ b/src/sdputils.js
@@ -259,14 +259,13 @@
      // If the codec is available, set it as the default in m line.
      var payload = null;
      for (var i = 0; i < sdpLines.length; i++) {
-      var index = findLineInRange(sdpLines, i, -1, 'a=rtpmap', codec);
-      if(index !== null) {
-        payload = getCodecPayloadTypeFromLine(sdpLines[index])
-        if (payload) {
-          sdpLines[mLineIndex] = setDefaultCodec(sdpLines[mLineIndex], payload);
-          i = index++;
-        }
-      }
+       var index = findLineInRange(sdpLines, i, -1, 'a=rtpmap', codec);
+       if(index !== null) {
+         payload = getCodecPayloadTypeFromLine(sdpLines[index]);
+         if (payload) {
+           sdpLines[mLineIndex] = setDefaultCodec(sdpLines[mLineIndex], payload);
+         }
+       }
      }
      
      sdp = sdpLines.join('\r\n');


### PR DESCRIPTION
This fixes many different issues with H264 SDP offers by ensuring that all H264 profiles now and in the future will precede other codecs when H264 is set as default codec.